### PR TITLE
set required_approving_review_count to 0

### DIFF
--- a/otterdog/eclipse-jifa.jsonnet
+++ b/otterdog/eclipse-jifa.jsonnet
@@ -59,7 +59,7 @@ orgs.newOrg('technology.jifa', 'eclipse-jifa') {
         orgs.newBranchProtectionRule('main') {
           dismisses_stale_reviews: true,
           is_admin_enforced: true,
-          required_approving_review_count: 1,
+          required_approving_review_count: 0,
         },
       ],
       environments: [


### PR DESCRIPTION
Hi,

Please help review this change that sets required_approving_review_count to 0.

Given that Jifa project does not have multiple active reviewers, and after this change, I can merge the PRs I created without approving review.

Thanks.